### PR TITLE
Add organization profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,43 @@
+# Actions Ecosystem
+
+Actions Ecosystem is a community-driven project that maintains many simple, independent GitHub Actions.
+
+The GitHub Actions are designed to be easily integrated with others, even ones developed by another project or your own.
+
+## Getting Started
+
+To get started with this project, it'd be recommended to go through the [recipes](https://github.com/actions-ecosystem/recipes).
+
+## Users
+
+The GitHub Actions maintained in this project are used and loved by 4000+ users (repositories), including:
+
+- [Ansible](https://github.com/ansible)
+- [Elastic](https://github.com/elastic)
+- [Ethereum](https://github.com/ethereum)
+- [Firebase](https://github.com/firebase)
+- [GitHub Actions](https://github.com/actions)
+- [GitLab](https://github.com/gitlabhq)
+- [Google](https://github.com/google)
+- [GoogleContainerTools](https://github.com/GoogleContainerTools)
+- [Grafana](https://github.com/grafana)
+- [Hashicorp](https://github.com/hashicorp)
+- [Jenkins](https://github.com/jenkinsci)
+- [Kubernetes](https://github.com/kubernetes)
+- [Microsoft](https://github.com/microsoft)
+- [PHP](https://github.com/php)
+- [Rust](https://github.com/rust-lang)
+- [Sentry](https://github.com/getsentry)
+- [Sourcegraph](https://github.com/sourcegraph)
+- [Weaveworks](https://github.com/weaveworks)
+- [World Wide Web Consortium](https://github.com/w3c)
+
+Note that the above list of users is found as of writing.
+
+## Looking for Sponsors
+
+Actions Ecosystem is currently maintained primarily by [@micnncim](https://github.com/micnncim) as volunteering.
+
+To continuously maintain and improve this project with keeping healthy, I want your help!
+
+Contributions are welcome, but it'd be great if you consider becoming a sponsor of this project or me.


### PR DESCRIPTION
Adds an initial profile for this project.

See
https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile for more information.